### PR TITLE
Support dynamic source copy from oem-cdimag-script

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -108,6 +108,9 @@ do
 			make bin-extras CD=1 ROOTSRC=$CDIMAGE_ROOT/oem-cdimage-script/ DIR=postinstall
 			make bin-extras CD=1 ROOTSRC=$CDIMAGE_ROOT/oem-cdimage-script/ DIR=pool
 			make bin-extras CD=1 ROOTSRC=$CDIMAGE_ROOT/oem-cdimage-script/ DIR=boot
+			for src in $OEMPROJECT_SRC; do
+				make bin-extras CD=1 ROOTSRC=$CDIMAGE_ROOT/oem-cdimage-script/ DIR=$src
+			done
 			. $CDIMAGE_ROOT/oem-cdimage-script/clean-pool.sh
 		fi
 		make bin-official_images $SIZE_ARGS SRCSIZELIMIT=$FULL_SIZE


### PR DESCRIPTION
When the environment variable OEMPROJECT_SRC present,
the sources files or dirs will be copied to CD image.
The OEMPROJECT_SRC can include multiple sources.
e.g: OEMPROJECT_SRC='file1 dir1 dir2'